### PR TITLE
AC5E compatibility patches

### DIFF
--- a/src/utils/activity.js
+++ b/src/utils/activity.js
@@ -294,7 +294,7 @@ export class ActivityUtility {
         const activity = ActivityUtility._getActivityFromMessage(message);
         const actor    = ActivityUtility._getActorFromMessage(message);
 
-        if (!activity || !actor || typeof activity.rollDamage !== "function") return null;
+        if (!activity || !actor || typeof activity.rollDamage !== "function" || !(activity.getDamageConfig?.({})?.rolls?.length)) return null;
 
         // Resolve scaling from system data (5.3.0 canonical) with flags fallback.
         const scaling = message.system?.scaling ?? message.flags?.dnd5e?.scaling ?? 0;

--- a/src/utils/hooks.js
+++ b/src/utils/hooks.js
@@ -11,12 +11,12 @@ import { SETTING_NAMES, SettingsUtility } from "./settings.js";
 export const HOOKS_CORE = { INIT: "init", READY: "ready" }
 
 export const HOOKS_DND5E = {
-    PRE_ROLL_ABILITY_CHECK: "dnd5e.preRollAbilityCheckV2",
-    PRE_ROLL_SAVING_THROW: "dnd5e.preRollSavingThrowV2",
-    PRE_ROLL_SKILL: "dnd5e.preRollSkillV2",
-    PRE_ROLL_TOOL_CHECK: "dnd5e.preRollToolV2",
-    PRE_ROLL_ATTACK: "dnd5e.preRollAttackV2",
-    PRE_ROLL_DAMAGE: "dnd5e.preRollDamageV2",
+    PRE_ROLL_ABILITY_CHECK: "dnd5e.preRollAbilityCheck",
+    PRE_ROLL_SAVING_THROW: "dnd5e.preRollSavingThrow",
+    PRE_ROLL_SKILL: "dnd5e.preRollSkill",
+    PRE_ROLL_TOOL_CHECK: "dnd5e.preRollTool",
+    PRE_ROLL_ATTACK: "dnd5e.preRollAttack",
+    PRE_ROLL_DAMAGE: "dnd5e.preRollDamage",
     PRE_USE_ACTIVITY: "dnd5e.preUseActivity",
     // POST_USE_ACTIVITY removed: in dnd5e 5.3.0 we use usageConfig.subsequentActions = false
     // in PRE_USE_ACTIVITY instead of returning false from POST_USE_ACTIVITY to block auto-rolls.


### PR DESCRIPTION
Working on compatibility of the modules I unsurfaced an interaction when RSReforged triggers an `activity.rollDamage()` for an activity with no damage parts.
```js
foundry.mjs:34224 Uncaught (in promise) TypeError: Cannot read properties of undefined (reading 'class')
[Detected 2 packages: system:dnd5e(5.3.3), rsreforged(4.6.0)]
    at DamageRoll._evaluateASTAsync (foundry.mjs:34224:15)
    at DamageRoll._evaluate (foundry.mjs:34205:30)
    at async DamageRoll.buildEvaluate (basic-roll.mjs:158:35)
    at async DamageRoll.build (basic-roll.mjs:73:5)
    at async SaveActivity.rollDamage (mixin.mjs:904:21)
    at async ActivityUtility.runActivityActions (activity.js:161:31)
    at async ChatUtility.processChatMessage (chat.js:71:21)
```

Also, I moved the RSReforged V2 Hooks, into the canonical nonV2 Hooks.

Check: https://discord.com/channels/170995199584108546/670336046164213761/1510662223859814570

I am hooking on the nonV2 as well, and helps if I go in a way _last_