### PR TITLE
AC5e compatibility and additional damage bonus options

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,17 +153,16 @@ Effect Value format:
 | `<damageType>` | A bare dnd5e damage type (e.g. `fire`). Fixes the bonus to that type on damage rolls — no dialog, no randomness. |
 | `random:<type,type,...>` | On a damage roll, pick one of the listed types at random each time the bonus is applied. |
 | `choice:<type,type,...>` | On a damage roll, show a dropdown of the listed types in the bonus dialog so the player picks. |
-| `fixed:<type>` | On a damage roll, uses the damage type each time the bonus is applied. |
 | `consume:origin` | Consume one charge of the originating item when applied |
 | `consume:<id-or-name>` | Consume one charge of a different item |
 | `once` | Delete the effect after a single use |
 
-Damage-type tokens accept dnd5e damage type keys (`acid`, `cold`, `fire`, `force`, `lightning`, `necrotic`, `poison`, `psychic`, `radiant`, `thunder`, `bludgeoning`, `piercing`, `slashing`). They apply only to damage rolls; on any other roll type the bonus is added untyped.
+Damage-type tokens accept dnd5e damage type keys (`acid`, `cold`, `fire`, `force`, `lightning`, `necrotic`, `poison`, `psychic`, `radiant`, `thunder`, `bludgeoning`, `piercing`, `slashing`). They apply only to damage rolls; on any other roll type the bonus is added untyped. (for example `2d6; type: check, damage;  lightning` would add 2d6 to either a skill check or 2d6 lightning damage to a damage roll)
 
 Examples:
 
 - **Bless:** `1d4; type:check, save, attack` (no consumption, since Bless is a duration spell)
-- **Bardic Inspiration (d8):** `1d8; type:any; consume:origin; once`
+- **Bardic Inspiration (d8):** `1d8; type:check, save, attack; consume:origin; once`
 - **Guidance:** `1d4; type:check; consume:origin; once`
 
 ## Known issues

--- a/README.md
+++ b/README.md
@@ -140,19 +140,25 @@ Add an Active Effect change on the actor (or on an item that grants the effect) 
 Effect Value format:
 
 ```
-<formula>; type:<roll-type[,roll-type...]>; consume:<origin|item-id|item-name>; once
+<formula>; type:<roll-type[,roll-type...]>; random:<type,type,...>; consume:<origin|item-id|item-name>; once
 ```
 
 | Token | Meaning |
 |---|---|
-| `<formula>` | A Roll formula. May reference `@actor.system.*` etc. |
+| `<formula>` | A Roll formula. May reference `@actor.system.*` etc. Omit it alongside a damage-type token to add `0` of that type — a pure type tag. |
 | `type:check` | Ability, skill, tool, and initiative checks |
 | `type:save` | Saves, including death saves and concentration |
 | `type:attack`, `type:damage`, `type:initiative` | That roll type only |
 | `type:any` (default) | Any roll type |
+| `<damageType>` | A bare dnd5e damage type (e.g. `fire`). Fixes the bonus to that type on damage rolls — no dialog, no randomness. |
+| `random:<type,type,...>` | On a damage roll, pick one of the listed types at random each time the bonus is applied. |
+| `choice:<type,type,...>` | On a damage roll, show a dropdown of the listed types in the bonus dialog so the player picks. |
+| `fixed:<type>` | On a damage roll, uses the damage type each time the bonus is applied. |
 | `consume:origin` | Consume one charge of the originating item when applied |
 | `consume:<id-or-name>` | Consume one charge of a different item |
 | `once` | Delete the effect after a single use |
+
+Damage-type tokens accept dnd5e damage type keys (`acid`, `cold`, `fire`, `force`, `lightning`, `necrotic`, `poison`, `psychic`, `radiant`, `thunder`, `bludgeoning`, `piercing`, `slashing`). They apply only to damage rolls; on any other roll type the bonus is added untyped.
 
 Examples:
 

--- a/src/utils/activity.js
+++ b/src/utils/activity.js
@@ -493,4 +493,4 @@ async function _animateNewRolls(newRolls, message) {
     if (!CoreUtility.dice3dAnimatesRollUpdates()) {
         await CoreUtility.tryRollDice3D(newRolls, message.id);
     }
-}
+} 

--- a/src/utils/activity.js
+++ b/src/utils/activity.js
@@ -184,6 +184,15 @@ export class ActivityUtility {
             } else {
                 message.flags[MODULE_SHORT].isCritical = false;
             }
+
+            // Register this card as its own "attack" roll message so condition
+            // modules (AC5e) and dnd5e's native attack->damage association can find
+            // the attack roll via dnd5e.registry.messages.get(<cardId>, "attack").
+            // RSR rolls with create:false and emits no discrete attack message, so
+            // the registry would otherwise have no attack entry for this card. Must
+            // run BEFORE the damage roll below so the lookup resolves during the
+            // damage roll's hooks on the quick-roll (attack+damage) path.
+            ActivityUtility._registerCardAsAttack(message, currentRolls);
         }
 
         if (message.flags[MODULE_SHORT].renderDamage) {
@@ -220,6 +229,11 @@ export class ActivityUtility {
                 type: ROLL_TYPE.ATTACK,
                 ...(attackRoll.options?.mastery ? { mastery: attackRoll.options.mastery } : {})
             };
+            // Persist the self-link so dnd5e's ChatMessage5e#prepareData ->
+            // MessageRegistry.track re-registers this card under the "attack" hook on
+            // every load. Pairs with the chat.js _injectContent guard that stops a
+            // self-referencing card from being treated as its own merge parent.
+            message.flags.dnd5e.originatingMessage = message.id;
         }
 
         await ChatUtility.updateChatMessage(message, {
@@ -258,6 +272,52 @@ export class ActivityUtility {
             flags: message.flags,
             rolls: serializedRolls
         });
+    }
+
+    /**
+     * Register the activation card as its own "attack" roll message in dnd5e's
+     * MessageRegistry, so dnd5e.registry.messages.get(<cardId>, "attack") resolves to
+     * this card and its stored attack D20Roll. RSR rolls with create:false and emits no
+     * discrete attack message, so without this the registry has no attack entry and
+     * condition modules (AC5e) / dnd5e's native attack->damage association cannot
+     * recover the attack roll's advantage state.
+     *
+     * Uses in-memory updateSource (no DB write, no re-render — the same pattern RSR
+     * already uses in preCreateChatMessage) so the live document immediately exposes
+     * the attack roll and the self-link, then tracks it explicitly. The self-link is
+     * also persisted by runActivityActions' final update, so prepareData re-registers
+     * the card on reload.
+     *
+     * Safe despite the self-referential originatingMessage: chat.js _injectContent
+     * guards against treating a self-referencing card as its own merge parent.
+     * @param {ChatMessage} message The activation card.
+     * @param {Array<Roll|object>} currentRolls Rolls gathered so far (must include the attack).
+     */
+    static _registerCardAsAttack(message, currentRolls) {
+        const attackRoll = (currentRolls ?? []).find(r => RollUtility.isRollOfType(r, CONFIG.Dice.D20Roll));
+        if (!attackRoll || !message?.id) return;
+
+        const rollFlag = {
+            ...(message.flags?.dnd5e?.roll ?? {}),
+            type: ROLL_TYPE.ATTACK,
+            ...(attackRoll.options?.mastery ? { mastery: attackRoll.options.mastery } : {})
+        };
+
+        // In-memory only: expose the attack roll + self-link on the live document so
+        // both the registry lookup and AC5e's rolls[0] read resolve during the
+        // immediately following damage roll. runActivityActions persists the final
+        // state afterwards.
+        message.updateSource({
+            rolls: CoreUtility.serializeRolls(currentRolls),
+            "flags.dnd5e.roll": rollFlag,
+            "flags.dnd5e.originatingMessage": message.id
+        });
+
+        try {
+            dnd5e.registry?.messages?.track?.(message);
+        } catch (err) {
+            console.warn("RSReforged | failed to register card as attack roll message:", err);
+        }
     }
 
     /**
@@ -370,6 +430,13 @@ export class ActivityUtility {
         const messageConfig = { create: false, data: { flags: {} }, flags: {} };
         messageConfig.data.flags[MODULE_SHORT] = { quickRoll: true };
         messageConfig.flags[MODULE_SHORT]      = { quickRoll: true };
+        // Anchor this damage roll to its card so condition modules (AC5e) resolve the
+        // originating attack via dnd5e.registry.messages.get(<cardId>, "attack"). AC5e
+        // reads flags.dnd5e.originatingMessage off the message config's `data` (the
+        // dot-notation key first, then the nested object), so set both shapes.
+        messageConfig.data["flags.dnd5e.originatingMessage"] = message.id;
+        messageConfig.data.flags.dnd5e = { originatingMessage: message.id };
+        messageConfig.flags.dnd5e      = { originatingMessage: message.id };
 
         return activity.rollDamage(config, dialogConfig, messageConfig);
     }

--- a/src/utils/bonus.js
+++ b/src/utils/bonus.js
@@ -119,19 +119,32 @@ export class BonusManager {
                 }
 
                 // Damage-type keywords (meaningful on damage rolls only):
+                //   <damageType>             -> a bare dnd5e damage type key (e.g. "fire") fixes
+                //                               the bonus to that type, with no dialog or rolling
                 //   random: <type,type,...>  -> pick one of the listed types at random on apply
                 //   choice: <type,type,...>  -> player picks one of the listed types in the dialog
-                // The listed values are dnd5e damage types (fire, cold, acid, ...). With no
+                // The listed values are dnd5e damage type keys (fire, cold, acid, ...). With no
                 // explicit formula the bonus contributes 0 of the resolved type (a pure tag).
+                const damageTypeKeys = new Set(Object.keys(CONFIG.DND5E?.damageTypes ?? {}));
                 const randomPart = parts.find(p => p.toLowerCase().startsWith("random:"));
                 const choicePart = parts.find(p => p.toLowerCase().startsWith("choice:"));
-                const damagePart = randomPart ?? choicePart;
-                const damageMode = randomPart ? "random" : (choicePart ? "choice" : null);
+                // A standalone part that is exactly a known damage type key (e.g. "fire").
+                const fixedTypePart = parts.find(p => damageTypeKeys.has(p.toLowerCase()));
+
+                let damageMode = null;
                 let damageTypeOptions = [];
-                if (damagePart) {
-                    // Everything after the first colon is the comma-separated type list.
-                    damageTypeOptions = damagePart.slice(damagePart.indexOf(":") + 1)
+                if (randomPart) {
+                    damageMode = "random";
+                    damageTypeOptions = randomPart.slice(randomPart.indexOf(":") + 1)
                         .split(",").map(t => t.trim().toLowerCase()).filter(Boolean);
+                } else if (choicePart) {
+                    damageMode = "choice";
+                    damageTypeOptions = choicePart.slice(choicePart.indexOf(":") + 1)
+                        .split(",").map(t => t.trim().toLowerCase()).filter(Boolean);
+                } else if (fixedTypePart) {
+                    // Bare damage type: a single fixed type, resolved with no dialog.
+                    damageMode = "fixed";
+                    damageTypeOptions = [fixedTypePart.toLowerCase()];
                 }
 
                 const formulaParts = parts.filter(p => 
@@ -139,7 +152,8 @@ export class BonusManager {
                     !p.toLowerCase().startsWith("consume") && 
                     p.toLowerCase() !== "once" &&
                     !p.toLowerCase().startsWith("random:") &&
-                    !p.toLowerCase().startsWith("choice:")
+                    !p.toLowerCase().startsWith("choice:") &&
+                    !damageTypeKeys.has(p.toLowerCase())
                 );
                 
                 let rawFormula = formulaParts.length > 0 ? formulaParts[0] : "0";
@@ -361,6 +375,11 @@ class BonusSelector extends ApplicationV2 {
                     <div style="margin-top: 6px; margin-left: 44px; font-size: 0.8em; opacity: 0.7;">
                         <i class="fas fa-dice"></i> Random type: ${opts.join(", ")}
                     </div>`;
+            } else if (b.damageMode === "fixed" && opts.length) {
+                typeUI = `
+                    <div style="margin-top: 6px; margin-left: 44px; font-size: 0.8em; opacity: 0.7;">
+                        <i class="fas fa-tag"></i> ${opts[0].charAt(0).toUpperCase() + opts[0].slice(1)} damage
+                    </div>`;
             }
 
             html += `
@@ -414,6 +433,8 @@ class BonusSelector extends ApplicationV2 {
             damageType = formData.object[`damageType-${index}`] || opts[0] || null;
         } else if (bonus?.damageMode === "random" && opts.length) {
             damageType = opts[Math.floor(Math.random() * opts.length)];
+        } else if (bonus?.damageMode === "fixed" && opts.length) {
+            damageType = opts[0];
         }
 
         await this.onSubmitCallback({ isCustom: false, index, damageType });

--- a/src/utils/bonus.js
+++ b/src/utils/bonus.js
@@ -118,10 +118,28 @@ export class BonusManager {
                     consumeTarget = split.length > 1 ? split[1].trim() : "origin";
                 }
 
+                // Damage-type keywords (meaningful on damage rolls only):
+                //   random: <type,type,...>  -> pick one of the listed types at random on apply
+                //   choice: <type,type,...>  -> player picks one of the listed types in the dialog
+                // The listed values are dnd5e damage types (fire, cold, acid, ...). With no
+                // explicit formula the bonus contributes 0 of the resolved type (a pure tag).
+                const randomPart = parts.find(p => p.toLowerCase().startsWith("random:"));
+                const choicePart = parts.find(p => p.toLowerCase().startsWith("choice:"));
+                const damagePart = randomPart ?? choicePart;
+                const damageMode = randomPart ? "random" : (choicePart ? "choice" : null);
+                let damageTypeOptions = [];
+                if (damagePart) {
+                    // Everything after the first colon is the comma-separated type list.
+                    damageTypeOptions = damagePart.slice(damagePart.indexOf(":") + 1)
+                        .split(",").map(t => t.trim().toLowerCase()).filter(Boolean);
+                }
+
                 const formulaParts = parts.filter(p => 
                     !p.toLowerCase().startsWith("type:") && 
                     !p.toLowerCase().startsWith("consume") && 
-                    p.toLowerCase() !== "once"
+                    p.toLowerCase() !== "once" &&
+                    !p.toLowerCase().startsWith("random:") &&
+                    !p.toLowerCase().startsWith("choice:")
                 );
                 
                 let rawFormula = formulaParts.length > 0 ? formulaParts[0] : "0";
@@ -152,7 +170,9 @@ export class BonusManager {
                         rawFormula: rawFormula,
                         resolvedFormula: resolvedFormula,
                         isOnce: isOnce,
-                        consumeTarget: consumeTarget
+                        consumeTarget: consumeTarget,
+                        damageMode: damageMode,
+                        damageTypeOptions: damageTypeOptions
                     });
                 }
             }
@@ -163,7 +183,11 @@ export class BonusManager {
             type: type,
             onSubmit: async (result) => {
                 let bonusDef = result.isCustom ? { name: "Custom Bonus", rawFormula: result.formula, isOnce: false } : bonuses[result.index];
-                if (bonusDef) await this.applyBonus(message, type, bonusDef, actor);
+                if (bonusDef) {
+                    // Carry the resolved damage type (from a random/choice bonus) into apply.
+                    if (result.damageType) bonusDef = { ...bonusDef, damageType: result.damageType };
+                    await this.applyBonus(message, type, bonusDef, actor);
+                }
             }
         }).render(true);
     }
@@ -211,7 +235,20 @@ export class BonusManager {
             
             if (!cleanFormula || cleanFormula.trim() === "") return ui.notifications.warn("Invalid bonus formula.");
 
-            const bonusRoll = new TargetRollClass(cleanFormula, rollData, originalRoll.options);
+            // Tag the bonus with its damage type (from a random/choice keyword) so it is
+            // appended as a typed segment, e.g. 2d6[fire]. Only meaningful when adding to a
+            // damage roll; a damage type on a d20 bonus has no meaning and is ignored.
+            let effectiveFormula = cleanFormula;
+            const damageType = bonusDef.damageType;
+            if (damageType && originalRoll instanceof CONFIG.Dice.DamageRoll) {
+                // Wrap multi-term formulas so the flavor applies to the whole bonus
+                // ("(1d6 + 2)[fire]"); a single term takes the flavor directly ("2d6[fire]").
+                // A leading +/- sign is ignored when testing for operators.
+                const needsParens = /[+\-*/]/.test(cleanFormula.trim().replace(/^[+-]/, ""));
+                effectiveFormula = needsParens ? `(${cleanFormula})[${damageType}]` : `${cleanFormula}[${damageType}]`;
+            }
+
+            const bonusRoll = new TargetRollClass(effectiveFormula, rollData, originalRoll.options);
             await bonusRoll.evaluate();
 
             const newTerms = [
@@ -246,7 +283,8 @@ export class BonusManager {
                 const effect = actor.effects.get(bonusDef.effectId);
                 if (effect) await effect.delete();
             }
-            ui.notifications.info(`Applied ${bonusDef.name} (+${bonusRoll.total}).`);
+            const typeLabel = bonusDef.damageType ? ` ${bonusDef.damageType}` : "";
+            ui.notifications.info(`Applied ${bonusDef.name} (+${bonusRoll.total}${typeLabel}).`);
 
         } catch (err) {
             LogUtility.logError(`Error applying bonus: ${err.message}`, { ui: true });
@@ -303,13 +341,38 @@ class BonusSelector extends ApplicationV2 {
                 </div>`;
 
         this.bonuses.forEach((b, i) => {
+            const checked = (i === 0 && !customChecked) ? "checked" : "";
+
+            // Optional damage-type UI for random/choice bonuses.
+            let typeUI = "";
+            const opts = b.damageTypeOptions ?? [];
+            if (b.damageMode === "choice" && opts.length) {
+                const optionHtml = opts.map(t =>
+                    `<option value="${t}">${t.charAt(0).toUpperCase() + t.slice(1)}</option>`
+                ).join("");
+                typeUI = `
+                    <div class="rsr-bonus-damage-type" style="margin-top: 8px; margin-left: 44px;">
+                        <label style="font-size: 0.85em; opacity: 0.85;">Damage type:
+                            <select name="damageType-${i}" style="margin-left: 6px;">${optionHtml}</select>
+                        </label>
+                    </div>`;
+            } else if (b.damageMode === "random" && opts.length) {
+                typeUI = `
+                    <div style="margin-top: 6px; margin-left: 44px; font-size: 0.8em; opacity: 0.7;">
+                        <i class="fas fa-dice"></i> Random type: ${opts.join(", ")}
+                    </div>`;
+            }
+
             html += `
-                <div class="form-group" style="display:flex; align-items:center; padding: 8px; border: 1px solid var(--color-border-light-2); border-radius: 4px; background: var(--color-bg-light);">
-                    <input type="radio" name="bonusIndex" value="${i}" id="bonus-${i}" ${i === 0 && !customChecked ? "checked" : ""}>
-                    <label for="bonus-${i}" style="display:flex; align-items:center; cursor:pointer; flex:1; margin-left:12px;">
-                        <img src="${b.icon}" width="32" height="32" style="border:none; margin-right:12px;">
-                        <div><strong>${b.name}</strong><br><small>${b.rawFormula}</small></div>
-                    </label>
+                <div class="form-group" style="padding: 8px; border: 1px solid var(--color-border-light-2); border-radius: 4px; background: var(--color-bg-light);">
+                    <div style="display:flex; align-items:center;">
+                        <input type="radio" name="bonusIndex" value="${i}" id="bonus-${i}" ${checked}>
+                        <label for="bonus-${i}" style="display:flex; align-items:center; cursor:pointer; flex:1; margin-left:12px;">
+                            <img src="${b.icon}" width="32" height="32" style="border:none; margin-right:12px;">
+                            <div><strong>${b.name}</strong><br><small>${b.rawFormula}</small></div>
+                        </label>
+                    </div>
+                    ${typeUI}
                 </div>`;
         });
 
@@ -331,13 +394,28 @@ class BonusSelector extends ApplicationV2 {
     _replaceHTML(result, content) { content.replaceChildren(result); }
 
     async _handleSubmit(event, form, formData) {
-        if (this.onSubmitCallback) {
-            if (formData.object.bonusIndex === "custom") {
-                if (!formData.object.customFormula) return ui.notifications.warn("Enter formula.");
-                await this.onSubmitCallback({ isCustom: true, formula: formData.object.customFormula });
-            } else {
-                await this.onSubmitCallback({ isCustom: false, index: parseInt(formData.object.bonusIndex) });
-            }
+        if (!this.onSubmitCallback) return;
+
+        if (formData.object.bonusIndex === "custom") {
+            if (!formData.object.customFormula) return ui.notifications.warn("Enter formula.");
+            await this.onSubmitCallback({ isCustom: true, formula: formData.object.customFormula });
+            return;
         }
+
+        const index = parseInt(formData.object.bonusIndex);
+        const bonus = this.bonuses[index];
+
+        // Resolve the damage type for random/choice bonuses:
+        //   choice -> the type the player picked in the dialog (fallback: first listed)
+        //   random -> a type picked at random from the list, chosen at apply time
+        let damageType = null;
+        const opts = bonus?.damageTypeOptions ?? [];
+        if (bonus?.damageMode === "choice") {
+            damageType = formData.object[`damageType-${index}`] || opts[0] || null;
+        } else if (bonus?.damageMode === "random" && opts.length) {
+            damageType = opts[Math.floor(Math.random() * opts.length)];
+        }
+
+        await this.onSubmitCallback({ isCustom: false, index, damageType });
     }
 }

--- a/src/utils/chat.js
+++ b/src/utils/chat.js
@@ -496,7 +496,14 @@ async function _injectContent(message, type, html) {
         if (origin && origin !== message) parent = origin;
     }
     if (!parent && typeof message.getAssociatedMessage === "function") parent = message.getAssociatedMessage();
-    if (!parent && message.flags?.dnd5e?.originatingMessage) parent = game.messages.get(message.flags.dnd5e.originatingMessage);
+    // Ignore a self-referential originatingMessage: RSR stamps the card's own id as
+    // its originatingMessage so dnd5e's MessageRegistry tracks it under the "attack"
+    // hook (letting condition modules resolve the attack roll for damage). Such a card
+    // is the root, not a child — resolving it here would make it its own merge parent.
+    if (!parent && message.flags?.dnd5e?.originatingMessage
+        && message.flags.dnd5e.originatingMessage !== message.id) {
+        parent = game.messages.get(message.flags.dnd5e.originatingMessage);
+    }
     if (!parent && message.system?.message) parent = game.messages.get(message.system.message);
     
     message.flags[MODULE_SHORT].displayChallenge = parent?.shouldDisplayChallenge ?? message.shouldDisplayChallenge;


### PR DESCRIPTION
## Summary

This PR adds AC5e (Automated Conditions 5e) compatibility for advantage-dependent bonuses, and introduces a brand-new damage-type system for the retroactive bonus feature.

## Problem

**AC5e advantage-dependent bonuses don't fire on RSR cards.** RSR rolls attack and damage with `create: false` and suppresses dnd5e's subsequent-action chain, so no discrete attack-roll message is ever created. Automation modules like AC5e reconstruct attack context (including advantage state) by looking up the attack roll in dnd5e's `MessageRegistry`. Since RSR cards aren't registered there, AC5e can't find the attack's advantage state, and effects like `bonus=60; hasAdvantage` never fire on RSR cards — even when the attack was correctly rolled with advantage.

**No way to specify a damage type on retroactive bonuses.** A bonus formula was always appended untyped, so features with elemental riders, random-damage effects, and player-choice damage types couldn't be represented as pre-defined bonuses.

## Solution

### 1. Register RSR cards in dnd5e's MessageRegistry (`activity.js` + `chat.js`)

- **`activity.js` (`_registerCardAsAttack`):** After the attack roll and before the damage roll, stamp `flags.dnd5e.originatingMessage = message.id` (self-link) and call `dnd5e.registry.messages.track()`. The registry now resolves `get(<cardId>, "attack")` to the card itself, exposing its D20Roll with the resolved `advantageMode`.
- **`activity.js` (`getDamageFromMessage`):** Anchor the damage roll's `messageConfig` to the card via `flags.dnd5e.originatingMessage`, so AC5e's lookup chain finds the originating attack.
- **`activity.js` (`runActivityActions`):** Persist the self-link in the final message update so the registry re-registers the card on reload.
- **`chat.js` (`_injectContent` guard):** Add `&& message.flags.dnd5e.originatingMessage !== message.id` to the fallback that reads the raw flag, preventing a self-referencing card from being treated as its own merge parent.

**Result:** AC5e's damage hook now finds the attack roll, `hasAdvantage` resolves correctly, and advantage-dependent bonuses fire on RSR cards in both the auto-roll and manual-damage-button paths, with or without a target selected.

### 2. New damage-type system for retroactive bonuses (`bonus.js`)

Three new, complementary ways to attach a damage type to a bonus:

**Bare type (fixed):**

```
2d6; type:damage; fire
```

Always deals the specified type — no dialog, no randomness. Validated against `CONFIG.DND5E.damageTypes`.

**Random selection:**

```
1d6; type:damage; random:acid, cold, fire, lightning, poison, thunder
```

Picks one of the listed types at random on each application; re-randomizes per use.

**Player choice:**

```
2d6; type:damage; choice:fire, cold, lightning
```

Shows a dropdown in the bonus dialog so the player picks before confirming.

All three modes:

- Apply only to damage rolls; the type is ignored on attack, save, and check rolls.
- Support no-formula usage: `; type:damage; fire` adds `0[fire]` as a pure type tag.
- Are safe on multi-roll bonuses: a bonus with `type:damage, attack` appends `2d6[fire]` on damage and a plain `+2d6` on attack.
- Integrate with existing keywords (`consume:`, `once`, etc.).

## Testing

**AC5e compatibility:**

- Auto-roll path (attack + damage in one click): bonus fires with advantage
- Manual-damage-button path: bonus fires when damage is rolled separately
- No target selected: bonus fires correctly
- With target selected: bonus fires correctly
- Card rendering: no glitches, no double-injection, merge logic unaffected

**Bonus damage-type system:**

- Fixed-type with no formula: `; type:damage; fire` → `0[fire]`
- Fixed-type with formula: `2d6; type:damage; fire` → `2d6[fire]`
- Random-type: re-randomizes on each application
- Choice-type: dropdown rendered correctly, selection flows through apply
- Multi-roll bonus: typed on damage, untyped on attack
- Invalid type keyword: falls through to formula parsing, caught by dnd5e at roll time

## Tested on

- Foundry VTT v14.363
- dnd5e 5.3.3
- Automated Conditions 5e v14.533.4.1

## Documentation

The "Setting up pre-defined bonuses" section of the README has been updated to document the new damage-type system with worked examples (fixed type, random, choice, multi-roll, and pure type tags).

## Files Changed

- `src/utils/activity.js` — card self-registration + damage-roll anchoring
- `src/utils/chat.js` — self-reference guard in `_injectContent`
- `src/utils/bonus.js` — new damage-type system
- `README.md` — updated bonus documentation

## Notes for Arrowedisgaming

- **AC5e fix** relies on dnd5e's `MessageRegistry` contract (`track()`, `prepareData()` registration, flag keying). Stable across dnd5e 5.x; would need revisiting on a major version bump.
- **Damage-type parsing** is conservative — a bare word is only treated as a type if it exactly matches a `CONFIG.DND5E.damageTypes` key. Typos fall through to formula parsing and surface as a clear dnd5e roll error.